### PR TITLE
[WIP] Add ability to generate insert with returning statement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,9 @@
 
 source 'https://rubygems.org'
 
-gem 'veritas', '~> 0.0.7',  :github => 'dkubb/veritas'
+gem 'veritas-sql-generator', :path => '.'
+
+gem 'veritas', '~> 0.0.7',  :github => 'solnic/veritas', :branch => 'key-attributes'
 
 group :development do
   gem 'jeweler', '~> 1.8.3'

--- a/lib/veritas/sql/generator/relation.rb
+++ b/lib/veritas/sql/generator/relation.rb
@@ -165,8 +165,8 @@ module Veritas
         # @return [#to_s]
         #
         # @api private
-        def column_list_for(columns, header = nil)
-          sql = columns.values_at(*(header || @header))
+        def column_list_for(columns, header = @header)
+          sql = columns.values_at(*header)
           sql.compact!
           sql.join(SEPARATOR)
         end

--- a/lib/veritas/sql/generator/relation.rb
+++ b/lib/veritas/sql/generator/relation.rb
@@ -165,8 +165,8 @@ module Veritas
         # @return [#to_s]
         #
         # @api private
-        def column_list_for(columns)
-          sql = columns.values_at(*@header)
+        def column_list_for(columns, header = nil)
+          sql = columns.values_at(*(header || @header))
           sql.compact!
           sql.join(SEPARATOR)
         end

--- a/lib/veritas/sql/generator/relation/insertion.rb
+++ b/lib/veritas/sql/generator/relation/insertion.rb
@@ -19,7 +19,7 @@ module Veritas
           #
           # @api private
           def visit_veritas_relation_operation_insertion(insertion)
-            @header = insertion.header.reject(&:key?)
+            @header = insertion.header - insertion.header.keys
             set_columns(insertion)
             set_operands(insertion)
             set_returning(insertion)
@@ -57,7 +57,7 @@ module Veritas
               util   = self.class
               left   = normalized.left
               right  = normalized.right
-              header = left.header.reject(&:key?)
+              header = left.header - left.header.keys
 
               @left  = util.visit(left.class.new(left.name, header))
               @right = util.visit(right.project(header).materialize)
@@ -68,7 +68,7 @@ module Veritas
 
           # @api private
           def set_returning(relation)
-            keys       = relation.header.select(&:key?)
+            keys       = relation.header.keys
             @returning = column_list_for(@columns, keys) if keys.any?
           end
 

--- a/spec/unit/veritas/sql/generator/relation/insertion/visit_veritas_relation_operation_insertion_spec.rb
+++ b/spec/unit/veritas/sql/generator/relation/insertion/visit_veritas_relation_operation_insertion_spec.rb
@@ -15,6 +15,17 @@ describe SQL::Generator::Relation::Insertion, '#visit_veritas_relation_operation
   let(:name)          { Attribute::String.new(:name)                     }
   let(:age)           { Attribute::Integer.new(:age, :required => false) }
 
+  context 'inserting a non-empty materialized relation and returning key attributes' do
+    let(:other) { operand.materialize                       }
+    let(:id)    { Attribute::Integer.new(:id, :key => true) }
+    let(:body)  { [ [ nil, 'Dan Kubb', 36 ] ].each               }
+
+    it_should_behave_like 'a generated SQL expression'
+
+    its(:to_s)        { should eql('INSERT INTO users ("name", "age") VALUES (\'Dan Kubb\', 36) RETURNING "id"') }
+    its(:to_subquery) { should eql('INSERT INTO users ("name", "age") VALUES (\'Dan Kubb\', 36) RETURNING "id"') }
+  end
+
   context 'inserting a non-empty materialized relation' do
     let(:other) { operand.materialize            }
     let(:body)  { [ [ 1, 'Dan Kubb', 36 ] ].each }

--- a/spec/unit/veritas/sql/generator/relation/insertion/visit_veritas_relation_operation_insertion_spec.rb
+++ b/spec/unit/veritas/sql/generator/relation/insertion/visit_veritas_relation_operation_insertion_spec.rb
@@ -18,7 +18,7 @@ describe SQL::Generator::Relation::Insertion, '#visit_veritas_relation_operation
   context 'inserting a non-empty materialized relation and returning key attributes' do
     let(:other) { operand.materialize                       }
     let(:id)    { Attribute::Integer.new(:id, :key => true) }
-    let(:body)  { [ [ nil, 'Dan Kubb', 36 ] ].each               }
+    let(:body)  { [ [ nil, 'Dan Kubb', 36 ] ].each          }
 
     it_should_behave_like 'a generated SQL expression'
 


### PR DESCRIPTION
This is a spike but I'm opening a PR early to get some input.

I also added key attributes to veritas [here](https://github.com/solnic/veritas/tree/key-attributes) and somehow make the inserts working in veritas-do-adapter [here](https://github.com/solnic/veritas-do-adapter/tree/writes).

I think it would be good to extend `Tuple` so it can return all attributes, only key attributes or all non-key attributes. This would make it a bit easier.

I'm also not sure if the way I change insertion's left and right on-the-fly is a good idea.

Basically I did the simplest thing that could possibly work :)
